### PR TITLE
Re-register entangled fallen qBlock to registry

### DIFF
--- a/src/main/java/dan200/qcraft/shared/TileEntityQBlock.java
+++ b/src/main/java/dan200/qcraft/shared/TileEntityQBlock.java
@@ -600,6 +600,8 @@ public class TileEntityQBlock extends TileEntity
             m_sideBlockTypes[ i ] = nbttagcompound.getInteger( "s" + i );
             m_forceObserved[ i ] = nbttagcompound.getBoolean( "c" + i );
         }
+        
+        validate();
     }
 
     @Override


### PR DESCRIPTION
After an entangled qBlock has changed to a falling state (sand or gravel) and back it has to be re-registered to the EntanglementRegistry to not lose its entanglement.